### PR TITLE
Cache result with once_cell

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ categories = ["command-line-utilities"]
 
 [dependencies]
 is-docker = "0.1.0"
+once_cell = "1.17.0"
 sys-info = "0.9.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -1,0 +1,8 @@
+extern crate is_wsl;
+fn main() {
+    if is_wsl::is_wsl() {
+        println!("Currently in WSL")
+    } else {
+        println!("Currently NOT in WSL")
+    }
+}


### PR DESCRIPTION
Hello! Thanks for creating this crate; I spotted it in my GitHub feed and was quite happy because [the older `wsl` crate](https://github.com/Dentosal/wsl-rs) has been abandoned. Hopefully `is-wsl` can be a nice replacement for `wsl`.

If you're open to PRs, this PR caches the `is_wsl()` result with [`once_cell`](https://github.com/matklad/once_cell). It's similar to [a PR I made for `wsl`](https://github.com/Dentosal/wsl-rs/pull/5), which was motivated by a situation in [Nushell](https://github.com/nushell/nushell) where we want to (frequently) check WSL status before rendering interactive content.

I know it's not ideal to add a dependency, but `once_cell` is _extremely_ widely used, so much so that [it's already in `std` on nightly](https://github.com/rust-lang/rust/issues/74465). Once it's stabilized, the external dependency will no longer be needed.

I also added an example (`cargo run --example main`) just to make manual testing a bit easier.