### PR TITLE
cargo clippy and update is-docker

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 categories = ["command-line-utilities"]
 
 [dependencies]
-is-docker = "0.1.0"
+is-docker = "0.2.0"
 once_cell = "1.17.0"
 sys-info = "0.9.1"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,10 +32,10 @@ pub fn is_wsl() -> bool {
             return true;
         }
 
-        return if proc_version_includes_microsoft() {
+        if proc_version_includes_microsoft() {
             !is_docker::is_docker()
         } else {
             false
-        };
+        }
     })
 }


### PR DESCRIPTION
This PR does the following: 

* bumps is-docker to 0.2.0. 
* removes an unnecessary return statement found by `cargo clippy`