### PR TITLE
Remove sys-info dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,5 @@ categories = ["command-line-utilities"]
 [dependencies]
 is-docker = "0.2.0"
 once_cell = "1.17.0"
-sys-info = "0.9.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,15 +1,8 @@
 extern crate is_docker;
 extern crate once_cell;
-extern crate sys_info;
 
 use once_cell::sync::OnceCell;
-
-fn proc_version_includes_microsoft() -> bool {
-    match std::fs::read_to_string("/proc/version") {
-        Ok(file_contents) => file_contents.to_lowercase().contains("microsoft"),
-        Err(_) => false,
-    }
-}
+use std::{fs::File, io::Read};
 
 pub fn is_wsl() -> bool {
     static CACHED_RESULT: OnceCell<bool> = OnceCell::new();
@@ -19,17 +12,10 @@ pub fn is_wsl() -> bool {
             return false;
         }
 
-        if sys_info::os_release().is_ok()
-            && sys_info::os_release()
-                .unwrap()
-                .to_lowercase()
-                .contains("microsoft")
-        {
-            if is_docker::is_docker() {
-                return false;
+        if let Ok(os_release) = get_os_release() {
+            if os_release.to_lowercase().contains("microsoft") {
+                return !is_docker::is_docker();
             }
-
-            return true;
         }
 
         if proc_version_includes_microsoft() {
@@ -38,4 +24,42 @@ pub fn is_wsl() -> bool {
             false
         }
     })
+}
+
+fn proc_version_includes_microsoft() -> bool {
+    match std::fs::read_to_string("/proc/version") {
+        Ok(file_contents) => file_contents.to_lowercase().contains("microsoft"),
+        Err(_) => false,
+    }
+}
+
+// This function is copied from the sys-info crate to avoid taking a dependency on all of sys-info
+// https://docs.rs/sys-info/0.9.1/src/sys_info/lib.rs.html#426-433
+//
+// The MIT License (MIT)
+//
+// Copyright (c) 2015 Siyu Wang
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+fn get_os_release() -> Result<String, std::io::Error> {
+    let mut s = String::new();
+    File::open("/proc/sys/kernel/osrelease")?.read_to_string(&mut s)?;
+    s.pop(); // pop '\n'
+    Ok(s)
 }


### PR DESCRIPTION
Hi there,

This PR removes the `sys-info` dependency, which is [relatively large with a few dependencies of its own](https://lib.rs/crates/sys-info). Because we only use a tiny part of `sys-info` (the Linux part of `os_release()`), it's easy to "inline" what we need and avoid taking a dependency.

I think this makes sense to keep compile times and binary size down, especially on non-Linux platforms where we don't need anything from `sys-info`. Let me know what you think!

## Licensing

`sys-info` is MIT-licensed, so [as I understand it](https://softwareengineering.stackexchange.com/a/234829/351884) this is OK because I've copied [the copyright+permission notices](https://github.com/FillZpp/sys-info-rs/blob/1c119b37ac0737466cd450f1fa7fb03af28024c8/LICENSE) verbatim. Doing so in source code comments seemed easiest.