### PR TITLE
chore: remove once_cell dependency and replace with std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,5 @@ categories = ["command-line-utilities"]
 
 [dependencies]
 is-docker = "0.2.0"
-once_cell = "1.17.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,10 @@
 extern crate is_docker;
-extern crate once_cell;
 
-use once_cell::sync::OnceCell;
+use std::sync::OnceLock;
 use std::{fs::File, io::Read};
 
 pub fn is_wsl() -> bool {
-    static CACHED_RESULT: OnceCell<bool> = OnceCell::new();
+    static CACHED_RESULT: OnceLock<bool> = OnceLock::new();
 
     *CACHED_RESULT.get_or_init(|| {
         if std::env::consts::OS != "linux" {


### PR DESCRIPTION
Removes once_cell dependency and replaces it with std, this should resolve #2. 